### PR TITLE
Second draft.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,57 @@ The repo is definitely "alpha".  Possibly "pre-alpha", if that's a thing.  At th
 Basically anything is subject to change.  This includes any of the API, the project name, and even the project's existence.  It was initially created to help me understand how Python's async stuff worked, and has grown as I've decided that the asyncio lib is lower-level than I want to deal with, and as I explored different "well now how do I do this?" questions.
 
 Feedback, new issues, suggestions, criticisms, etc are welcomed and encouraged.  If the project turns out to be truly worth it, I'll be happy to have shared it.  If not, I'll be happy to have learned why it's not, and how to do async in python better.
+
+# Thoughts
+The below are some thoughts about using the async support in python - they're a little stream-of-consciousness, and
+only very lightly edited.
+
+Python runs in a sync context - need to support async calls in the sync context, which means supporting
+subcomponents using the event loop.  Or some other loop.  Or some other async runner (like the curio kernel).  Code
+should not make any assumptions about the context it's running in.
+
+You can await any number of levels down, but if you want to add something to the current event loop...you'll get an
+async future back, which requires knowledge of the loop it was created for to be running in order to use properly. 
+Unfortunately, asyncio doesn't yet allow you to figure that out, so you have to be careful about passing those futures 
+around.  It seems to me that asyncio futures should only be used at the same level as the asyncio event loop is used.
+There is an unfortunate implicit dependency there which is further complicated by the asynchronous nature of the
+library and is even harder to reason about in the face of mutliple threads... I would recommend that any use of asyncio
+futures be tightly controlled.
+
+Levels of concurrency:
+* When to be serial - when you want to do a single operation and don't want anything else to happen till it's done.
+* When to be concurrent in a single thread - when you have things you want done concurrently, but none of them are
+blocking.
+* When to be concurrent in multiple threads - when you have blocking operations.
+* When to be multi-process - when your cpu fills up.
+* When to be multi-host - when all your cpu's fill up.
+
+So...you want single-threaded-blocking if you want just one thing done at the top level, logical concurrency any
+other time, thread-concurrency when you have truly blocking operations, and actual temporal concurrency when you've run out
+of computation power in your processor, or when you can actually break things into independent tasks such that actually
+running in parallel actually gets you a speed boost that you care about..  (this can be expanded to other hosts, not
+just other cpu's, though you want minimal communication the further apart your parts are (single-threaded-blocking ->
+single-threaded concurrent -> multi-threaded concurrent -> multiprocess-concurrent -> multi-host concurrent))
+
+The only dependable "top-level" is the `__main__` script area.  Any function calls you define and call in the main
+script can be called from within other functions and from other modules, and you can't ever know if they're being run
+concurrently or not.  Even the main script is often refactored out into a function call, which can then be used
+anywhere.
+
+From that, I'd reason that you always want to be concurrent.  The major advantage of `await` is that you get to pick
+where your thread's control moves off to run other things, which allows you to explicitly run areas of code 'atomically'
+in your thread without dealing with locks/semaphores/events.  From that, I'd reason that most of the time you want to
+use the await-style concurrency instead of thread-level concurrency.
+
+So forget the synchronous context.  Write everything new asynchronously.  Wrap all the blocking calls.
+
+Stretch goals:
+* find a way to simulate the await 'atomic' guarantees in threads, because threads are always going to be necessary
+for dealing with blocking calls.
+* find a way to grow your executor thread pool when you need more blocking concurrency and there's CPU available.
+* find a way to grow and load balance into threads on other processors.
+* find a way to grow and load balance into processors on other hosts.
+
+Further musings given the stretch goals - this assumes you want python for other reasons than concurrency.  there are 
+other languages which are explicitly designed for concurrency from the start, and usually features designed into the
+lanugage are easier to work with than libraries built on top are.

--- a/examples.py
+++ b/examples.py
@@ -5,14 +5,14 @@
 # [ -Python ]
 import asyncio
 import time
-import pprint
+# import pprint
 
 # [ -Project ]
 import a_sync
 
 
 # [ Examples ]
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: no branch
     def hello(name, seconds):
         """Hello."""
         print('hello {}'.format(name))
@@ -45,6 +45,7 @@ if __name__ == '__main__':
 
     # a_sync.block(async_hello, 'jeff', 6)
 
+    bg = a_sync.queue_background_thread(hello, 'background-joe', 20)
     parallel_1 = a_sync.Parallel()
     parallel_1.schedule(hello, 'joe', 5)
     parallel_1.schedule(hello, 'sam', 3)
@@ -84,6 +85,7 @@ if __name__ == '__main__':
     final_parallel.schedule(serial_2.run)
 
     final_parallel.block()
+    bg.result()
     # pprint.pprint(all_results)
     # expect bob/sam/joe to start with jo/joey/joseph
     # expect jill/jane/mary to start with alex/alexandria/alexandra

--- a/helpers.py
+++ b/helpers.py
@@ -4,8 +4,6 @@
 # [ Imports ]
 # [ -Python ]
 import asyncio
-import inspect
-import contextlib
 import concurrent
 
 
@@ -28,49 +26,6 @@ def get_or_create_event_loop():
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
     return loop
-
-
-@contextlib.contextmanager
-def idle_event_loop():
-    """
-    An idle event loop context manager.
-
-    Leaves the current event loop in place if it's not running.
-    Creates and sets a new event loop as the default if the current default IS running.
-    Restores the original event loop on exit.
-    """
-    original_loop = get_or_create_event_loop()
-    try:
-        if original_loop.is_running():
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-        else:
-            loop = original_loop
-        yield loop
-    finally:
-        asyncio.set_event_loop(original_loop)
-
-
-async def to_awaitable(func):
-    """Turn a blocking function into an awaitable."""
-    # getting existing ok because we're not in a loop
-    # (need error handling in case we are?)
-    # might need to create because we might not be in the main thread.
-    # don't want to use a unique loop here because this runs in the caller's
-    # context, which we're not passing the loop back into.
-    # (creating the loop sets it in the global context... it would be
-    # better to make that explicit somehow)
-    loop = get_or_create_event_loop()
-    # create a loop inside the executor?
-    # allows everyone to use default loop
-    # adds unnecessary overhead for functions which don't need one...
-    # the common case will be that we don't need a loop, so let's not do that here.
-    # means anyone who wants to use a loop will have to get_or_create first.
-    # Run in executor returns a future, which is bound to the given loop.
-    # Don't return the future - you can't control the context it runs
-    # in if you do, and that might be a different event loop or thread,
-    # which will cause an error.  Await it here and return its results instead.
-    return await loop.run_in_executor(get_or_create_executor(), func)
 
 
 def get_or_create_executor():
@@ -96,48 +51,3 @@ def set_executor(executor):
 def create_executor():
     """Get an executor to run blocking functions in."""
     return concurrent.futures.ThreadPoolExecutor(EXECUTOR_THREAD_COUNT)
-
-
-def set_executor_thread_count(count):
-    """Set the executor thread count."""
-    global EXECUTOR_THREAD_COUNT
-    EXECUTOR_THREAD_COUNT = count
-
-
-def to_blocking(awaitable):
-    """Turn an awaitable function into a blocking function."""
-    def blocking():
-        """A blocking wrapper around an awaitable."""
-        # create and use a unique loop - we don't care if we're in a loop
-        # already or not, we just want to run the awaitable to completion.
-        # Doing so with the default loop is fine if nothing is running, but
-        # if it's already running we get an error.  Create and use a new event
-        # loop in that case.
-        # The expectation is that the awaitable is a coroutine object, not a future.
-        # XXX need defensive code here for ^.  Futures might be bound to a specific loop,
-        # which is fine if that loop is not running, and we can get to it and use it,
-        # but we're neither checking for that or doing that (pulling that loop out and using it).
-        # XXX need defensive code here in case the arg is not awaitable.
-        with idle_event_loop() as loop:
-            return loop.run_until_complete(awaitable)
-    return blocking
-
-
-def ensure_awaitable(func_or_awaitable):
-    """Return an awaitable, creating one if a blocking function is passed in."""
-    if inspect.isawaitable(func_or_awaitable):
-        awaitable = func_or_awaitable
-    else:
-        func = func_or_awaitable
-        awaitable = to_awaitable(func)
-    return awaitable
-
-
-def ensure_blocking(func_or_awaitable):
-    """Return a blocking function, creating one if an awaitable is passed in."""
-    if inspect.isawaitable(func_or_awaitable):
-        awaitable = func_or_awaitable
-        func = to_blocking(awaitable)
-    else:
-        func = func_or_awaitable
-    return func


### PR DESCRIPTION
Closes #21 
Closes #5 
Closes #4

I say "closes" instead of "fixes", because the draft's changes don't necessarily actually fix the issues, but where they don't, they make the issues irrelevant (for instance, because I decided not to make all the functions accept any asyncio/concurrent.futures objects).

Changes:
- removed a lot of the backgrounding cruft
- removed runnable scheduler
- added a bunch of documentation
- fixed parallel run function, and explained why it needed fixing.
- simplified the serial/parallel calls with functools.partial, and in the process made to_async and to_blocking partial-aware.
- added a bunch of musings to the readme.
- added better comments and removed dead code
- added background task to example file.
