### PR TITLE
Summary: Fixes #31 - async input

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This library provides simple functions for:
 * running multiple functions in series, either asynchronously or in a blocking fashion
 * getting/creating and setting/reverting an independent asyncio event loop to use, regardless of thread or thread-global
 asyncio loop run status.
+* async input
 
 # Under construction
 The repo is "under construction" - it serves at the moment as a place to put the project and "get it out there", but there are a lot of project-management tasks to do, including getting a sensible README up.
@@ -272,6 +273,17 @@ some object state)
 # API
 
 ## Functions
+### `async a_input(prompt: str) -> str`
+
+An async input function.  Basic functionality is the same as the standard `input`, though it's not affected by the
+readline library.
+
+**Args:**
+* prompt - the prompt to print before waiting for input.
+
+**Returns:**
+* user_input - the user input.
+
 ### `idle_event_loop() -> Generator`
 
 An idle event loop context manager.

--- a/a_sync/__init__.py
+++ b/a_sync/__init__.py
@@ -9,6 +9,7 @@ from a_sync.a_sync import (
     queue_background_thread,
     run,
     block,
+    a_input,
     Parallel,
     Serial
 )
@@ -21,5 +22,6 @@ assert to_blocking
 assert queue_background_thread
 assert run
 assert block
+assert a_input
 assert Parallel
 assert Serial


### PR DESCRIPTION
**Problem:**
No async input function.  `input` blocks and can't be cancelled.

**Analysis:**
Add an async input function which can be cancelled.

**Testing:**
Manual

**Documentation:**
Updated README.md for a_input.

**Impact:**
Minor - new feature, backwards compatible.
