### PR TITLE
Summary: Fixes #35 - static checkers

### DIFF
--- a/check.yaml
+++ b/check.yaml
@@ -6,3 +6,4 @@ checks:
     - [pylint, '{changed}']
     - [flake8, '{changed}']
     - [mypy, -s, --fast-parser, --disallow-untyped-defs]
+    - [dodgy]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 
 # [ Imports ]
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 
 # [ Setup ]
@@ -35,4 +35,14 @@ setup(
     keywords="async await asynchronous library parallel background",
     packages=find_packages(),
     install_requires=[],
+    extras_require={
+        'checkers': [
+            'pocketwalk',
+            'dodgy',
+            'flake8-bugbear', 'flake8-docstrings', 'flake8-import-order',
+            'mypy-lang', 'typed-ast',
+            'pylint',
+            'vulture',
+        ]
+    }
 )


### PR DESCRIPTION
**Problem:**
Static checkers weren't configured correctly to install, and there were
some failures as-is.

**Analysis:**
* various fixups for more modern python checker failures
* added dodgy checker
* adding static checking tools to an extras section in the installer.

**Testing:**
Locally.

**Documentation:**
None.

**Impact:**
Patch - fixing static check failures and adding extras-installs