### PR TITLE
Check if argument is a coroutine function before checking argument.func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+.pytest_cache/

--- a/a_sync/a_sync.py
+++ b/a_sync/a_sync.py
@@ -102,7 +102,7 @@ def to_async(blocking_func: AnyCallable) -> AnyCallable:
         * keep an async partial the same
         * validate that it doesn't matter if the loop is running.
     """
-    if asyncio.iscoroutinefunction(getattr(blocking_func, 'func', blocking_func)):
+    if asyncio.iscoroutinefunction(blocking_func) or asyncio.iscoroutinefunction(getattr(blocking_func, 'func', None)):
         # caller messed up - this is already async
         async_func = blocking_func
     else:
@@ -146,7 +146,7 @@ def to_blocking(async_func: AnyCallable) -> AnyCallable:
         * keep blocking partial the same
         * convert async partial
     """
-    if not asyncio.iscoroutinefunction(getattr(async_func, 'func', async_func)):
+    if not asyncio.iscoroutinefunction(async_func) or asyncio.iscoroutinefunction(getattr(async_func, 'func', None)):
         # caller messed up - this is already blocking
         blocking = async_func
     else:

--- a/a_sync/a_sync.py
+++ b/a_sync/a_sync.py
@@ -146,7 +146,7 @@ def to_blocking(async_func: AnyCallable) -> AnyCallable:
         * keep blocking partial the same
         * convert async partial
     """
-    if not asyncio.iscoroutinefunction(async_func) or asyncio.iscoroutinefunction(getattr(async_func, 'func', None)):
+    if not (asyncio.iscoroutinefunction(async_func) or asyncio.iscoroutinefunction(getattr(async_func, 'func', None))):
         # caller messed up - this is already blocking
         blocking = async_func
     else:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest==3.5.1
+asynctest==0.12.0
+pytest-asyncio==0.8.0

--- a/tests/test_a_sync.py
+++ b/tests/test_a_sync.py
@@ -1,0 +1,36 @@
+import a_sync
+import asynctest
+
+import pytest
+
+
+def test_block():
+    async def async_func():
+        return 5
+
+    def sync_func():
+        return 4
+
+    assert a_sync.block(async_func) == 5
+    assert a_sync.block(sync_func) == 4
+
+
+def test_block_works_with_CoroutineMock():
+    assert 3 == a_sync.block(asynctest.CoroutineMock(return_value=3))
+
+
+@pytest.mark.asyncio
+async def test_run():
+    async def async_func():
+        return 5
+
+    def sync_func():
+        return 4
+
+    assert await a_sync.run(async_func) == 5
+    assert await a_sync.run(sync_func) == 4
+
+
+@pytest.mark.asyncio
+async def test_run_works_with_CoroutineMock():
+    assert 3 == await a_sync.run(asynctest.CoroutineMock(return_value=3))

--- a/tests/test_a_sync.py
+++ b/tests/test_a_sync.py
@@ -1,7 +1,9 @@
-import a_sync
-import asynctest
+import functools
 
+import asynctest
 import pytest
+
+import a_sync
 
 
 def test_block():
@@ -13,6 +15,20 @@ def test_block():
 
     assert a_sync.block(async_func) == 5
     assert a_sync.block(sync_func) == 4
+
+
+def test_block_partials():
+    def sync_func_to_partial(retval):
+        return retval
+
+    async def async_func_to_partial(retval):
+        return retval
+
+    sync_partial = functools.partial(sync_func_to_partial, 5)
+    async_partial = functools.partial(async_func_to_partial, 4)
+
+    assert a_sync.block(sync_partial) == 5
+    assert a_sync.block(async_partial) == 4
 
 
 def test_block_works_with_CoroutineMock():
@@ -34,3 +50,18 @@ async def test_run():
 @pytest.mark.asyncio
 async def test_run_works_with_CoroutineMock():
     assert 3 == await a_sync.run(asynctest.CoroutineMock(return_value=3))
+
+
+@pytest.mark.asyncio
+async def test_run_partials():
+    def sync_func_to_partial(retval):
+        return retval
+
+    async def async_func_to_partial(retval):
+        return retval
+
+    sync_partial = functools.partial(sync_func_to_partial, 5)
+    async_partial = functools.partial(async_func_to_partial, 4)
+
+    assert await a_sync.run(sync_partial) == 5
+    assert await a_sync.run(async_partial) == 4

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py36
+
+[testenv]
+basepython = python3.6
+deps =
+	--requirement={toxinidir}/requirements-dev.txt
+commands =
+	py.test {posargs:tests}


### PR DESCRIPTION
I kept running into issues with [asynctest.CoroutineMock](http://asynctest.readthedocs.io/en/latest/asynctest.mock.html#asynctest.CoroutineMock) and a_sync.block():

    >>> import asynctest
    >>> import a_sync
    >>> import asyncio
    >>> a_sync.block(asynctest.CoroutineMock(return_value=5))
    <generator object CoroutineMock._mock_call.<locals>.proxy at 0x7f4113e57c50>
    >>> asyncio.get_event_loop().run_until_complete(asynctest.CoroutineMock(return_value=5)())
    5

This is because CoroutineMock returns a MagicMock for any undefined attribute access:

    >>> foo = asynctest.CoroutineMock()
    >>> foo.func
    <MagicMock name='mock.func' id='139917444876440'>
    >>> foo.bar
    <MagicMock name='mock.bar' id='139917444622824'>
    >>>

Since `to_blocking` currently checks `async_func.func` first (which is not a coroutine function), it treats the CoroutineMock like a sync function, even though:

    >>> asyncio.iscoroutinefunction(foo)
    True